### PR TITLE
Add cache/caches to rule exceptions

### DIFF
--- a/pluralize.go
+++ b/pluralize.go
@@ -307,6 +307,7 @@ func (c *Client) loadIrregularRules() { //nolint:funlen
 		{`passerby`, `passersby`},
 		{`canvas`, `canvases`},
 		{`sms`, `sms`},
+		{`cache`, `caches`},
 	}
 
 	for _, r := range irregularRules {

--- a/pluralize_test.go
+++ b/pluralize_test.go
@@ -938,6 +938,7 @@ func singularTests() []TestEntry {
 		{`nucleus`, `nucleuses`},
 		{`bureau`, `bureaux`},
 		{`seraph`, `seraphs`},
+		{`cache`, `caches`},
 	}
 }
 


### PR DESCRIPTION
Ensures caches becomes cache when made singular (otherwise it doesn't retain the e)